### PR TITLE
Aggiunta colonna Totale alla SELECT in RelTestataSQLBuilder

### DIFF
--- a/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/SEND/DatiRel/Queries/Persistence/Builder/RelTestataSQLBuilder.cs
+++ b/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/SEND/DatiRel/Queries/Persistence/Builder/RelTestataSQLBuilder.cs
@@ -125,7 +125,8 @@ SELECT [internal_organization_id] as IdEnte
         [Cup],
         [DataDocumento],
         [DatiFatturazione],
-        [Caricata]
+        [Caricata],
+        [Totale]
     FROM [be].[vwRelDettaglio]";
 
     private static string _offSet = " OFFSET (@page-1)*@size ROWS FETCH NEXT @size ROWS ONLY";


### PR DESCRIPTION
È stata aggiunta la colonna [Totale] alla query SQL nella classe RelTestataSQLBuilder, includendola tra i campi selezionati dalla vista [be].[vwRelDettaglio].