### PR TITLE
fix: 0691

### DIFF
--- a/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/SEND/DatiRel/Queries/Persistence/Builder/RelTestataSospesaSQLBuilder.cs
+++ b/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/SEND/DatiRel/Queries/Persistence/Builder/RelTestataSospesaSQLBuilder.cs
@@ -49,8 +49,8 @@ FROM (
     private static string _sqlCount = @"
             SELECT Count(internal_organization_id) 
             FROM pfd.RiepilogoFatturazione_NPF rf
-            inner join pfd.tmpRelTestata rt on rf.FkIdEnte = rt.internal_organization_id
-            and rf.AnnoRiferimento = rt.year and rf.MeseRiferimento = rt.month
+            inner join pfd.tmpRelTestata t on rf.FkIdEnte = t.internal_organization_id
+            and rf.AnnoRiferimento = t.year and rf.MeseRiferimento = t.month
             WHERE rf.PrimoSaldoSospeso = 1
     ";
 


### PR DESCRIPTION
Modificato l'alias della tabella temporanea pfd.tmpRelTestata da "rt" a "t" nella query assegnata a _sqlCount in RelTestataSospesaSQLBuilder.cs, garantendo coerenza nell'uso dell'alias nell'inner join e nelle condizioni di join.