### PR TITLE
feat: 704 Supporto nome DataTable in FillOneSheetv2<T>

### DIFF
--- a/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/SEND/Documenti/Common/ReflectionExtensions.cs
+++ b/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/SEND/Documenti/Common/ReflectionExtensions.cs
@@ -309,10 +309,11 @@ public static class ReflectionExtensions
         return ds;
     }
 
-    public static DataSet FillOneSheetv2<T>(this IEnumerable<T> data)
+    public static DataSet FillOneSheetv2<T>(this IEnumerable<T> data, string? dataTableName = null)
     {
         var ds = new DataSet();
-        var (table, headers) = ToTablev2<T>();
+
+        var (table, headers) = ToTablev2<T>(dataTableName);
         DataRow row;
         foreach (var d in data)
         {

--- a/src/Presentation/PortaleFatture.BE.Api/Modules/SEND/Fatture/FattureModule.cs
+++ b/src/Presentation/PortaleFatture.BE.Api/Modules/SEND/Fatture/FattureModule.cs
@@ -1710,7 +1710,7 @@ public partial class FattureModule
         var mime = "application/vnd.ms-excel";
         var filename = $"{Guid.NewGuid()}.xlsx";
 
-        var dataSet = report!.MapExport().FillOneSheetv2();
+        var dataSet = report!.MapExport().FillOneSheetv2("Andamento Credito Sosp.");
         var content = dataSet.ToExcel();
 
         return Results.Stream(content!, mime, filename);


### PR DESCRIPTION
Aggiunto parametro opzionale dataTableName a FillOneSheetv2<T> per consentire la personalizzazione del nome della DataTable/worksheet generata. Aggiornata la chiamata in FattureModule.cs per specificare "Andamento Credito Sosp." come nome del foglio Excel esportato.