### PR TITLE
fix: 711 - Gestione SEMESTRALE_SOSPESI in ReportNonFatturate (PF-711)

### DIFF
--- a/src/Presentation/PortaleFatture.BE.Api/Modules/SEND/Fatture/Extensions/FattureExtensions.cs
+++ b/src/Presentation/PortaleFatture.BE.Api/Modules/SEND/Fatture/Extensions/FattureExtensions.cs
@@ -843,6 +843,7 @@ public static class FattureExtensions
                 case TipologiaFattura.PRIMOSALDO:
                 case TipologiaFattura.SECONDOSALDO:
                 case TipologiaFattura.VAR_SEMESTRALE:
+                case TipologiaFattura.SEMESTRALE_SOSPESI:
                     var fatture = await handler.Send(new FattureRelExcelQuery(authInfo)
                     {
                         Anno = amt.Anno,


### PR DESCRIPTION
Aggiunto il caso TipologiaFattura.SEMESTRALE_SOSPESI nello switch del metodo ReportNonFatturate in FattureExtensions.cs, permettendo la gestione di questa tipologia con la stessa logica delle altre tipologie già presenti.