### PR TITLE
fix: 658 Refactor query email e test fallback mail referente

### DIFF
--- a/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/pagoPA/FinancialReports/Services/EmailPspService.cs
+++ b/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/pagoPA/FinancialReports/Services/EmailPspService.cs
@@ -49,28 +49,28 @@ AND Invio=0 AND trimestre = @year_quarter";
     WHERE trimestre = @year_quarter";
 
     private readonly string _sqlSelect = @"
-SELECT 
-    k.contract_id, 
-    c.name,
-    k.year_quarter,
-    ISNULL([referentefattura_mail],[courtesy_mail]) as email,
-    k.descrizione_riga as links,
-	linkReport as DiscountReport
-FROM   ppa.kpmg k
-INNER JOIN   [ppa].[Contracts] c
-ON     c.contract_id = k.contract_id
-AND    c.year_quarter = k.year_quarter
-left JOIN
-       (
-                       SELECT DISTINCT [recipient_id],
-                                       year_quarter ,
-                                       [linkReport]
-                       FROM            [ppa].[KpiPagamenti_Sconto]
-                       WHERE           percsconto > 0) AS sconti
-ON     k.contract_id = sconti.recipient_id 
-and k.year_quarter = sconti.year_quarter
-where k.year_quarter =@year_quarter
-AND    len(k.descrizione_riga) > 0";
+        SELECT 
+            k.contract_id, 
+            c.name,
+            k.year_quarter,
+            ISNULL(NULLIF([referentefattura_mail], ''), [courtesy_mail]) as email,
+            k.descrizione_riga as links,
+            linkReport as DiscountReport
+        FROM   ppa.kpmg k
+        INNER JOIN   [ppa].[Contracts] c
+        ON     c.contract_id = k.contract_id
+        AND    c.year_quarter = k.year_quarter
+        left JOIN
+            (
+                            SELECT DISTINCT [recipient_id],
+                                            year_quarter ,
+                                            [linkReport]
+                            FROM            [ppa].[KpiPagamenti_Sconto]
+                            WHERE           percsconto > 0) AS sconti
+        ON     k.contract_id = sconti.recipient_id 
+        and k.year_quarter = sconti.year_quarter
+        where k.year_quarter =@year_quarter
+        AND    len(k.descrizione_riga) > 0";
 
     private readonly string _sqlInsert = @"
 INSERT INTO [ppa].[PspEmail]

--- a/tests/Data/setup.sql
+++ b/tests/Data/setup.sql
@@ -39,6 +39,41 @@ IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'ppa')
 	EXEC ('CREATE SCHEMA ppa;');
 	END;
 
+IF OBJECT_ID('[ppa].[Contracts]', 'U') IS NULL
+BEGIN
+	CREATE TABLE [ppa].[Contracts]
+	(
+		[contract_id] NVARCHAR(100) NOT NULL,
+		[year_quarter] NVARCHAR(20) NOT NULL,
+		[name] NVARCHAR(500) NULL,
+		[referentefattura_mail] NVARCHAR(320) NULL,
+		[courtesy_mail] NVARCHAR(320) NULL,
+		CONSTRAINT [PK_ppa_Contracts] PRIMARY KEY CLUSTERED ([contract_id], [year_quarter])
+	);
+END;
+
+IF OBJECT_ID('[ppa].[kpmg]', 'U') IS NULL
+BEGIN
+	CREATE TABLE [ppa].[kpmg]
+	(
+		[contract_id] NVARCHAR(100) NOT NULL,
+		[year_quarter] NVARCHAR(20) NOT NULL,
+		[descrizione_riga] NVARCHAR(MAX) NULL,
+		CONSTRAINT [PK_ppa_kpmg] PRIMARY KEY CLUSTERED ([contract_id], [year_quarter])
+	);
+END;
+
+IF OBJECT_ID('[ppa].[KpiPagamenti_Sconto]', 'U') IS NULL
+BEGIN
+	CREATE TABLE [ppa].[KpiPagamenti_Sconto]
+	(
+		[recipient_id] NVARCHAR(100) NOT NULL,
+		[year_quarter] NVARCHAR(20) NOT NULL,
+		[linkReport] NVARCHAR(MAX) NULL,
+		[percsconto] DECIMAL(18,2) NULL
+	);
+END;
+
 IF OBJECT_ID('[ppa].[PspEmail]', 'U') IS NOT NULL
 BEGIN
 	IF COL_LENGTH('ppa.PspEmail', 'Oggetto') IS NULL
@@ -56,6 +91,24 @@ BEGIN
 		ALTER TABLE [ppa].[PspEmail] ADD [Link] NVARCHAR(MAX) NULL;
 	END;
 END;
+
+INSERT INTO [ppa].[Contracts] ([contract_id], [year_quarter], [name], [referentefattura_mail], [courtesy_mail])
+VALUES
+	('IT_RO_REF_2026_1', '2026_1', 'PSP ReadOnly Referente', 'referente.readonly@pagopa.it', 'courtesy.readonly@pagopa.it'),
+	('IT_RO_FBK_2026_1', '2026_1', 'PSP ReadOnly Fallback', '', 'courtesy.fallback@pagopa.it'),
+	('IT_RO_REF_2026_2', '2026_2', 'PSP ReadOnly Quarter Filter', 'q2@pagopa.it', 'q2-courtesy@pagopa.it');
+
+INSERT INTO [ppa].[kpmg] ([contract_id], [year_quarter], [descrizione_riga])
+VALUES
+	('IT_RO_REF_2026_1', '2026_1', 'agentquarter_link_ref,detailed_link_ref'),
+	('IT_RO_FBK_2026_1', '2026_1', 'agentquarter_link_fbk,detailed_link_fbk'),
+	('IT_RO_REF_2026_2', '2026_2', 'agentquarter_link_q2,detailed_link_q2');
+
+INSERT INTO [ppa].[KpiPagamenti_Sconto] ([recipient_id], [year_quarter], [linkReport], [percsconto])
+VALUES
+	('IT_RO_REF_2026_1', '2026_1', 'https://example.test/discount-report-ref', 10.00),
+	('IT_RO_FBK_2026_1', '2026_1', 'https://example.test/discount-report-fbk', 0.00),
+	('IT_RO_REF_2026_2', '2026_2', 'https://example.test/discount-report-q2', 15.00);
 
 CREATE TABLE pfw.CategoriaSpedizione (
 	IdCategoriaSpedizione int IDENTITY(1,1) NOT NULL,

--- a/tests/PortaleFatture.BE.IntegrationTest/EmailPspServiceIntegrationTests.cs
+++ b/tests/PortaleFatture.BE.IntegrationTest/EmailPspServiceIntegrationTests.cs
@@ -29,7 +29,7 @@ public class EmailPspServiceIntegrationTests
         var service = new EmailPspService(connectionString);
 
         var idContratto = $"IT_PREV_{Guid.NewGuid():N}";
-        var trimestre = "2026_Q3";
+        var trimestre = "2026_1";
         var data = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss");
 
         try
@@ -69,7 +69,7 @@ public class EmailPspServiceIntegrationTests
         var service = new EmailPspService(connectionString);
 
         var idContratto = $"IT_TRK_{Guid.NewGuid():N}";
-        var trimestre = "2026_Q3";
+        var trimestre = "2026_1";
         var data = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss");
 
         try
@@ -94,9 +94,9 @@ public class EmailPspServiceIntegrationTests
 
             var row = GetTrackingRow(connectionString, idContratto, trimestre);
             ClassicAssert.IsNotNull(row, "Inserted row not found in [ppa].[PspEmail]");
-            ClassicAssert.AreEqual("Tracking Oggetto", row!.Oggetto);
-            ClassicAssert.AreEqual("Tracking Corpo", row.Corpo);
-            ClassicAssert.AreEqual("https://example.test/tracking", row.Link);
+            Assert.That(row!.Oggetto, Is.EqualTo("Tracking Oggetto"));
+            Assert.That(row.Corpo, Is.EqualTo("Tracking Corpo"));
+            Assert.That(row.Link, Is.EqualTo("https://example.test/tracking"));
         }
         finally
         {
@@ -104,11 +104,171 @@ public class EmailPspServiceIntegrationTests
         }
     }
 
+    [Test]
+    public void GetSenderEmail_ReadOnly_ShouldUseReferenteMail_WhenNotEmpty()
+    {
+        var connectionString = Required("PortaleFattureOptions:ConnectionString");
+        var service = new EmailPspService(connectionString);
+        const string quarter = "2026_1";
+
+        var result = service.GetSenderEmail(quarter);
+
+        ClassicAssert.IsNotNull(result);
+        var expected = GetExpectedRowWithReferente(connectionString, quarter);
+        if (expected is null)
+        {
+            Assert.Pass($"No suitable referente record found for quarter {quarter}; read-only query executed successfully.");
+            return;
+        }
+
+        var row = result!.FirstOrDefault(x => x.IdContratto == expected.IdContratto);
+
+        ClassicAssert.IsNotNull(row, $"Contract {expected.IdContratto} not found in GetSenderEmail result.");
+        Assert.That(row!.Email, Is.EqualTo(expected.ExpectedEmail));
+        Assert.That(row.RagioneSociale, Is.EqualTo(expected.RagioneSociale));
+        Assert.That(row.AgentReport, Is.EqualTo(ParseReportLink(expected.Links, "agentquarter")));
+        Assert.That(row.DetailReport, Is.EqualTo(ParseReportLink(expected.Links, "detailed")));
+        Assert.That(row.DiscountReport, Is.EqualTo(expected.DiscountReport ?? string.Empty));
+    }
+
+    [Test]
+    public void GetSenderEmail_ReadOnly_ShouldFallbackToCourtesyMail_WhenReferenteEmpty()
+    {
+        var connectionString = Required("PortaleFattureOptions:ConnectionString");
+        var service = new EmailPspService(connectionString);
+        const string quarter = "2026_1";
+
+        var result = service.GetSenderEmail(quarter);
+
+        ClassicAssert.IsNotNull(result);
+        var expected = GetExpectedRowWithCourtesyFallback(connectionString, quarter);
+        if (expected is null)
+        {
+            Assert.Pass($"No suitable courtesy fallback record found for quarter {quarter}; read-only query executed successfully.");
+            return;
+        }
+
+        var fallbackRow = result!.FirstOrDefault(x => x.IdContratto == expected.IdContratto);
+
+        ClassicAssert.IsNotNull(fallbackRow, $"Contract {expected.IdContratto} not found in GetSenderEmail result.");
+        Assert.That(fallbackRow!.Email, Is.EqualTo(expected.ExpectedEmail));
+        Assert.That(fallbackRow.RagioneSociale, Is.EqualTo(expected.RagioneSociale));
+        Assert.That(fallbackRow.AgentReport, Is.EqualTo(ParseReportLink(expected.Links, "agentquarter")));
+        Assert.That(fallbackRow.DetailReport, Is.EqualTo(ParseReportLink(expected.Links, "detailed")));
+        Assert.That(fallbackRow.DiscountReport, Is.EqualTo(expected.DiscountReport ?? string.Empty), "DiscountReport should be empty when percsconto <= 0.");
+
+        Assert.That(result.Any(x => x.Trimestre != quarter), Is.False,
+            "Quarter filter regression: result contains records from a different quarter.");
+    }
+
     private string Required(string key)
     {
         var value = _conf.GetValue<string>(key);
         ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(value), $"{key} not configured (User Secrets)");
         return value!;
+    }
+
+    private static ExpectedSenderRow? GetExpectedRowWithReferente(string connectionString, string quarter)
+    {
+        const string sql = @"
+SELECT TOP 1
+    c.contract_id,
+    c.name,
+    c.referentefattura_mail,
+    k.descrizione_riga,
+    s.linkReport
+FROM [ppa].[kpmg] k
+INNER JOIN [ppa].[Contracts] c
+    ON c.contract_id = k.contract_id
+   AND c.year_quarter = k.year_quarter
+OUTER APPLY (
+    SELECT TOP 1 ks.linkReport
+    FROM [ppa].[KpiPagamenti_Sconto] ks
+    WHERE ks.recipient_id = k.contract_id
+      AND ks.year_quarter = k.year_quarter
+      AND ks.percsconto > 0
+    ORDER BY ks.linkReport
+) s
+WHERE k.year_quarter = @quarter
+  AND LEN(ISNULL(k.descrizione_riga, '')) > 0
+  AND LEN(LTRIM(RTRIM(ISNULL(c.referentefattura_mail, '')))) > 0
+ORDER BY c.contract_id;";
+
+        using var conn = new SqlConnection(connectionString);
+        conn.Open();
+        using var cmd = new SqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("@quarter", quarter);
+
+        using var reader = cmd.ExecuteReader();
+        if (!reader.Read())
+        {
+            return null;
+        }
+
+        return new ExpectedSenderRow(
+            IdContratto: reader.GetString(0),
+            RagioneSociale: reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+            ExpectedEmail: reader.IsDBNull(2) ? string.Empty : reader.GetString(2),
+            Links: reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
+            DiscountReport: reader.IsDBNull(4) ? null : reader.GetString(4));
+    }
+
+    private static ExpectedSenderRow? GetExpectedRowWithCourtesyFallback(string connectionString, string quarter)
+    {
+        const string sql = @"
+SELECT TOP 1
+    c.contract_id,
+    c.name,
+    c.courtesy_mail,
+    k.descrizione_riga,
+    s.linkReport
+FROM [ppa].[kpmg] k
+INNER JOIN [ppa].[Contracts] c
+    ON c.contract_id = k.contract_id
+   AND c.year_quarter = k.year_quarter
+OUTER APPLY (
+    SELECT TOP 1 ks.linkReport
+    FROM [ppa].[KpiPagamenti_Sconto] ks
+    WHERE ks.recipient_id = k.contract_id
+      AND ks.year_quarter = k.year_quarter
+      AND ks.percsconto > 0
+    ORDER BY ks.linkReport
+) s
+WHERE k.year_quarter = @quarter
+  AND LEN(ISNULL(k.descrizione_riga, '')) > 0
+  AND LEN(LTRIM(RTRIM(ISNULL(c.referentefattura_mail, '')))) = 0
+  AND LEN(LTRIM(RTRIM(ISNULL(c.courtesy_mail, '')))) > 0
+ORDER BY c.contract_id;";
+
+        using var conn = new SqlConnection(connectionString);
+        conn.Open();
+        using var cmd = new SqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("@quarter", quarter);
+
+        using var reader = cmd.ExecuteReader();
+        if (!reader.Read())
+        {
+            return null;
+        }
+
+        return new ExpectedSenderRow(
+            IdContratto: reader.GetString(0),
+            RagioneSociale: reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+            ExpectedEmail: reader.IsDBNull(2) ? string.Empty : reader.GetString(2),
+            Links: reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
+            DiscountReport: reader.IsDBNull(4) ? null : reader.GetString(4));
+    }
+
+    private static string? ParseReportLink(string links, string token)
+    {
+        if (string.IsNullOrWhiteSpace(links))
+        {
+            return null;
+        }
+
+        return links
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault(x => x.Contains(token, StringComparison.OrdinalIgnoreCase));
     }
 
     private static bool ExistsInPreview(string connectionString, string idContratto, string trimestre)
@@ -185,4 +345,11 @@ WHERE [IdContratto] = @IdContratto
     }
 
     private sealed record TrackingRow(string? Oggetto, string? Corpo, string? Link);
+
+    private sealed record ExpectedSenderRow(
+        string IdContratto,
+        string RagioneSociale,
+        string ExpectedEmail,
+        string Links,
+        string? DiscountReport);
 }

--- a/tests/PortaleFatture.BE.UnitTest/EmailPspServiceTests.cs
+++ b/tests/PortaleFatture.BE.UnitTest/EmailPspServiceTests.cs
@@ -2,6 +2,7 @@ using NUnit.Framework.Legacy;
 using PortaleFatture.BE.Core.Entities.pagoPA.AnagraficaPSP;
 using PortaleFatture.BE.Infrastructure.Common.pagoPA.FinancialReports.Dto;
 using PortaleFatture.BE.Infrastructure.Common.pagoPA.FinancialReports.Services;
+using System.Reflection;
 
 namespace PortaleFatture.BE.UnitTest;
 
@@ -20,7 +21,7 @@ public class EmailPspServiceTests
             IdContratto = "UT_PREVIEW",
             Tipologia = EmailPspTipologia.Financial,
             Anno = 2026,
-            Trimestre = "2026_Q3",
+            Trimestre = "2026_1",
             Data = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss"),
             Email = "unit-test@pagopa.it",
             Oggetto = "subject",
@@ -44,7 +45,7 @@ public class EmailPspServiceTests
             IdContratto = "UT_TRACK",
             Tipologia = EmailPspTipologia.Financial,
             Anno = 2026,
-            Trimestre = "2026_Q3",
+            Trimestre = "2026_1",
             Data = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss"),
             Email = "unit-test@pagopa.it",
             Messaggio = "message",
@@ -63,7 +64,7 @@ public class EmailPspServiceTests
     {
         var service = new EmailPspService(InvalidConnectionString);
 
-        var result = service.CountInvio("2026_Q3");
+        var result = service.CountInvio("2026_1");
 
         ClassicAssert.IsFalse(result);
     }
@@ -73,7 +74,7 @@ public class EmailPspServiceTests
     {
         var service = new EmailPspService(InvalidConnectionString);
 
-        var result = service.GetSenderEmail("2026_Q3");
+        var result = service.GetSenderEmail("2026_1");
 
         ClassicAssert.IsNotNull(result);
         ClassicAssert.IsEmpty(result!);
@@ -84,9 +85,42 @@ public class EmailPspServiceTests
     {
         var service = new EmailPspService(InvalidConnectionString);
 
-        var result = service.GetSenderEmailReinvio("2026_Q3");
+        var result = service.GetSenderEmailReinvio("2026_1");
 
         ClassicAssert.IsNotNull(result);
         ClassicAssert.IsEmpty(result);
+    }
+
+    [Test]
+    public void SqlSelect_ShouldContainFallbackFromReferenteToCourtesyMail()
+    {
+        var service = new EmailPspService(InvalidConnectionString);
+
+        var field = typeof(EmailPspService).GetField("_sqlSelect", BindingFlags.NonPublic | BindingFlags.Instance);
+        ClassicAssert.IsNotNull(field, "Private field _sqlSelect not found.");
+
+        var sql = field!.GetValue(service) as string;
+        ClassicAssert.IsNotNull(sql);
+
+        ClassicAssert.IsTrue(sql!.Contains("ISNULL(NULLIF([referentefattura_mail], ''), [courtesy_mail]) as email", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public void SqlSelect_ShouldPrioritizeReferenteBeforeCourtesyMail()
+    {
+        var service = new EmailPspService(InvalidConnectionString);
+
+        var field = typeof(EmailPspService).GetField("_sqlSelect", BindingFlags.NonPublic | BindingFlags.Instance);
+        ClassicAssert.IsNotNull(field, "Private field _sqlSelect not found.");
+
+        var sql = field!.GetValue(service) as string;
+        ClassicAssert.IsNotNull(sql);
+
+        var referIndex = sql!.IndexOf("[referentefattura_mail]", StringComparison.OrdinalIgnoreCase);
+        var courtesyIndex = sql.IndexOf("[courtesy_mail]", StringComparison.OrdinalIgnoreCase);
+
+        ClassicAssert.IsTrue(referIndex >= 0, "[referentefattura_mail] not found in _sqlSelect.");
+        ClassicAssert.IsTrue(courtesyIndex >= 0, "[courtesy_mail] not found in _sqlSelect.");
+        ClassicAssert.IsTrue(referIndex < courtesyIndex, "Expected referentefattura_mail to be evaluated before courtesy_mail.");
     }
 }


### PR DESCRIPTION
Aggiornato setup DB con dati di test per Contracts, kpmg e KpiPagamenti_Sconto. Modificata la query _sqlSelect per preferire la mail del referente, con fallback su courtesy_mail. Aggiunti test di integrazione per verificare la logica di priorità/fallback e metodi di supporto per il recupero dati attesi. Aggiornati i test esistenti per usare il trimestre "2026_1". Nei test unitari aggiunti controlli sulla corretta implementazione della logica di fallback nella query.