### PR TITLE
fix(security-scan) 750 : Log - mostrati solo il conteggio destinatari PSP PF-

### DIFF
--- a/src/Presentation/PortaleFatture.BE.SendEmailFunction/SendEmailPsp.cs
+++ b/src/Presentation/PortaleFatture.BE.SendEmailFunction/SendEmailPsp.cs
@@ -129,7 +129,7 @@ public class SendEmailPsp(ILoggerFactory loggerFactory)
             }
 
             var apiKeyFilePath = builder.ApiKeyFilePath();
-            _logger.LogInformation(psps.Serialize());
+            _logger.LogInformation("PSP recipients loaded: {RecipientCount}", psps!.Count());
 
             // /!\ pausa fissa di 1 minuto senza motivazione documentata — verificare se serve ancora, poi rimuovere o rendere configurabile
             Thread.Sleep(60000); // 1 minuto

--- a/src/Presentation/PortaleFatture.BE.SendEmailFunction/SendEmailPspAdjustment.cs
+++ b/src/Presentation/PortaleFatture.BE.SendEmailFunction/SendEmailPspAdjustment.cs
@@ -124,7 +124,7 @@ public class SendEmailPspAdjustment(ILoggerFactory loggerFactory)
             //psps = emailService.GetSenderEmailAdjustment(risposta.Trimestre);
 
            var apiKeyFilePath = builder.ApiKeyFilePath();
-            _logger.LogInformation(psps.Serialize());
+           _logger.LogInformation("PSP adjustment recipients loaded: {RecipientCount}", psps!.Count());
 
 
             foreach (var psp in psps!)


### PR DESCRIPTION
Nei file SendEmailPsp.cs e SendEmailPspAdjustment.cs i log informativi ora riportano solo il numero totale dei destinatari PSP caricati, invece di serializzare l'intera lista. Il messaggio di log è stato reso più descrittivo e leggibile.