### PR TITLE
fix(hot): Aggiunto SingleOrDefaultAsync e relativi test su DapperBase

### DIFF
--- a/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/Persistence/DapperBase.cs
+++ b/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/Persistence/DapperBase.cs
@@ -75,4 +75,18 @@ public abstract class DapperBase : IDatabase
         var task = connection.QuerySingleAsync<T>(sqlQuery, parameters, transaction, commandTimeout, type);
         return await Execute(task, connection, transaction);
     }
+
+    public async Task<T?> SingleOrDefaultAsync<T>(
+        IDbConnection connection,
+        string sqlQuery,
+        object? parameters,
+        IDbTransaction? transaction,
+        CommandType type,
+        int? commandTimeout = null)
+    {
+        // QuerySingleOrDefaultAsync: 0 righe -> default(T) (niente eccezione); >1 righe -> lancia
+        // (resta un segnale che la chiave non e' univoca come atteso).
+        var task = connection.QuerySingleOrDefaultAsync<T>(sqlQuery, parameters, transaction, commandTimeout, type);
+        return await Execute(task, connection, transaction);
+    }
 }

--- a/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/Persistence/IDatabase.cs
+++ b/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/Persistence/IDatabase.cs
@@ -11,5 +11,8 @@ public interface IDatabase
     Task<int> ExecuteAsync(IDbConnection connection, string sqlCommand, object? parameters, IDbTransaction? transaction = null, CommandType type = CommandType.Text, int? commandTimeout = null); 
     Task<T?> ExecuteAsync<T>(IDbConnection connection, string sqlCommand, object? parameters, IDbTransaction? transaction = null, CommandType type = CommandType.Text, int? commandTimeout = null); 
     Task<IEnumerable<T>> SelectAsync<T>(IDbConnection connection, string sqlCommand, object? parameters, IDbTransaction? transaction = null, CommandType type = CommandType.Text, int? commandTimeout = null);
-    Task<T> SingleAsync<T>(IDbConnection connection, string sqlCommand, object? parameters, IDbTransaction? transaction = null, CommandType type = CommandType.Text, int? commandTimeout = null); 
+    Task<T> SingleAsync<T>(IDbConnection connection, string sqlCommand, object? parameters, IDbTransaction? transaction = null, CommandType type = CommandType.Text, int? commandTimeout = null);
+    // Come SingleAsync ma NON lancia su 0 righe: ritorna default(T) (null per reference). Usare quando
+    // "non trovato" e' un esito legittimo che l'handler traduce in 404 (es. dettaglio per chiave).
+    Task<T?> SingleOrDefaultAsync<T>(IDbConnection connection, string sqlCommand, object? parameters, IDbTransaction? transaction = null, CommandType type = CommandType.Text, int? commandTimeout = null); 
 }

--- a/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/SEND/DatiRel/Queries/Persistence/RelTestataQueryGetByIdPersistence.cs
+++ b/src/Infrastructure/PortaleFatture.BE.Infrastructure/Common/SEND/DatiRel/Queries/Persistence/RelTestataQueryGetByIdPersistence.cs
@@ -57,6 +57,8 @@ public class RelTestataQueryGetByIdPersistence(RelTestataQueryGetById command) :
             IdContratto = idContratto
         };
 
+        // SingleAsync (non SingleOrDefault): per una chiave valida il dettaglio DEVE esistere, quindi
+        // 0 righe e' un'anomalia reale -> 500, non un 404 "risorsa assente". Il 500 attuale andrebbe individuato indagando la vista be.vwRelDettaglio
         return await ((IDatabase)this).SingleAsync<RelTestataDettaglioDto>(
             connection!,
             sqlEnte,

--- a/tests/PortaleFatture.BE.IntegrationTest/DapperBaseSingleTests.cs
+++ b/tests/PortaleFatture.BE.IntegrationTest/DapperBaseSingleTests.cs
@@ -1,0 +1,130 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using PortaleFatture.BE.Infrastructure.Common.Persistence;
+
+namespace PortaleFatture.BE.IntegrationTest;
+
+/// <summary>
+/// Integration test sul comportamento di DapperBase.SingleAsync vs SingleOrDefaultAsync con 0 / 1 / N
+/// righe. Contesto: il bug 500 su api/rel/pagopa/{id} nasce da SingleAsync usato dove la query puo'
+/// dare 0 righe (QuerySingleAsync lancia -> 500 invece di 404).
+///
+/// DECISIONE: per rel/pagopa/{id} il 500 su 0 righe e' CORRETTO -> per una chiave valida il dettaglio
+/// deve esistere, quindi l'assenza e' un'anomalia reale, non un 404. L'endpoint resta su SingleAsync.
+/// (Il 500 su SECONDO SALDO / SEM. SOSPESI ha causa a monte nella vista be.vwRelDettaglio, fix lato Data.)
+///
+/// SingleOrDefaultAsync resta comunque su DapperBase come utility generica per i casi in cui "non trovato"
+/// e' un esito legittimo: i suoi test sono ATTIVI e ne fissano il contratto (0 -> null, 1 -> valore,
+/// &gt;1 -> lancia). Entrambi i gruppi usano query DATA-INDEPENDENT.
+///
+/// Le query di sonda sono DATA-INDEPENDENT (SELECT letterali / VALUES): servono solo connettivita' al DB,
+/// nessun seed. Coerente con i test "strutturali" del progetto (es. FattureSospeseRelExcelQueryTests):
+/// senza connessione (VPN giu') il test risulta Ignored, non fallito.
+/// </summary>
+public class DapperBaseSingleTests
+{
+    private sealed class Probe : DapperBase { } // concreta: DapperBase e' abstract
+
+    private const string Sql0 = "SELECT CAST(1 AS int) WHERE 1 = 0";                      // 0 righe
+    private const string Sql1 = "SELECT CAST(42 AS int)";                                 // 1 riga -> 42
+    private const string SqlN = "SELECT x FROM (VALUES (1),(2)) AS t(x)";                 // 2 righe
+
+    private string _connectionString = null!;
+
+    [SetUp]
+    /// Verifica che la connessione al DB sia configurata e raggiungibile. Se non lo e', ignora i test.
+    public void Setup()
+    {
+        var conf = ServiceProvider.GetRequiredService<IConfiguration>();
+        _connectionString = conf["PortaleFattureOptions:ConnectionString"] ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(_connectionString))
+            Assert.Ignore("PortaleFattureOptions:ConnectionString non configurata: test DB saltato.");
+
+        // Se il DB non e' raggiungibile (es. VPN giu') degrada a Ignore invece di fallire.
+        try
+        {
+            using var probe = new SqlConnection(_connectionString);
+            probe.Open();
+        }
+        catch (Exception ex)
+        {
+            Assert.Ignore($"DB non raggiungibile ({ex.GetType().Name}): test DB saltato.");
+        }
+    }
+
+    private static IDatabase Db() => new Probe();
+    private IDbConnection Open()
+    {
+        var c = new SqlConnection(_connectionString);
+        c.Open();
+        return c; // i metodi DapperBase con transaction null chiudono la connessione (using) al termine
+    }
+
+    // ---------- SingleAsync: comportamento ATTUALE (attivi) ----------
+
+    [Test]
+    /// <summary>
+    /// Verifica che SingleAsync lanci un'eccezione quando la query restituisce 0 righe.
+    /// </summary>
+    public void SingleAsync_ZeroRows_Throws()
+    {
+        // E' esattamente la causa del 500 su rel/pagopa/{id}: 0 righe -> eccezione.
+        Assert.That(async () => await Db().SingleAsync<int>(Open(), Sql0, null, null, CommandType.Text),
+            Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    [Test]
+    /// <summary>
+    /// Verifica che SingleAsync restituisca il valore corretto quando la query restituisce 1 riga.
+    /// </summary>
+    public async Task SingleAsync_OneRow_ReturnsValue()
+    {
+        var r = await Db().SingleAsync<int>(Open(), Sql1, null, null, CommandType.Text);
+        Assert.That(r, Is.EqualTo(42));
+    }
+
+    [Test]
+    /// <summary>
+    /// Verifica che SingleAsync lanci un'eccezione quando la query restituisce più di 1 riga.
+    /// </summary>
+    public void SingleAsync_MultipleRows_Throws()
+    {
+        Assert.That(async () => await Db().SingleAsync<int>(Open(), SqlN, null, null, CommandType.Text),
+            Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    // ---------- SingleOrDefaultAsync: utility generica su DapperBase (attivi) ----------
+
+    [Test]
+    /// <summary>
+    /// Verifica che SingleOrDefaultAsync restituisca il valore di default quando la query restituisce 0 righe.
+    /// </summary>
+    public async Task SingleOrDefaultAsync_ZeroRows_ReturnsDefault()
+    {
+        var r = await Db().SingleOrDefaultAsync<int?>(Open(), Sql0, null, null, CommandType.Text);
+        Assert.That(r, Is.Null, "0 righe -> null (non deve lanciare): permette all'endpoint di fare 404.");
+    }
+
+    [Test]
+    /// <summary>
+    /// Verifica che SingleOrDefaultAsync restituisca il valore corretto quando la query restituisce 1 riga.
+    /// </summary>
+    public async Task SingleOrDefaultAsync_OneRow_ReturnsValue()
+    {
+        var r = await Db().SingleOrDefaultAsync<int>(Open(), Sql1, null, null, CommandType.Text);
+        Assert.That(r, Is.EqualTo(42));
+    }
+
+    [Test]
+    /// <summary>
+    /// Verifica che SingleOrDefaultAsync lanci un'eccezione quando la query restituisce più di 1 riga.
+    /// </summary>
+    public void SingleOrDefaultAsync_MultipleRows_Throws()
+    {
+        // Anche SingleOrDefault lancia su >1: il duplicato resta un segnale (chiave non univoca).
+        Assert.That(async () => await Db().SingleOrDefaultAsync<int>(Open(), SqlN, null, null, CommandType.Text),
+            Throws.InstanceOf<InvalidOperationException>());
+    }
+}

--- a/tests/PortaleFatture.BE.UnitTest/RelTestataKeyTests.cs
+++ b/tests/PortaleFatture.BE.UnitTest/RelTestataKeyTests.cs
@@ -1,0 +1,69 @@
+using PortaleFatture.BE.Core.Entities.SEND.DatiRel;
+
+namespace PortaleFatture.BE.UnitTest;
+
+/// <summary>
+/// Unit test PURI (nessun DB) su RelTestataKey: serializzazione/deserializzazione dell'id composito
+/// {IdEnte}_{IdContratto}_{TipologiaFattura}_{Anno}_{Mese} usato dalle rotte api/rel/pagopa/{id}.
+/// E' il punto dove le tipologie con spazio ("SECONDO SALDO", "SEM. SOSPESI", "VAR. SEMESTRALE")
+/// vengono mappate su trattino e viceversa; un errore qui manda la query del dettaglio su una chiave
+/// sbagliata.
+/// </summary>
+public class RelTestataKeyTests
+{
+    [Test]
+    /// <summary>
+    /// Verifica che la deserializzazione di un id valido estrae correttamente i campi. 
+    /// </summary>
+    public void Deserialize_IdValido_EstraeICampi()
+    {
+        var id = "76fd95f3-c1a1-410f-95c8-a6ac00989aae_97d4d355-ab9f-4a09-8fe1-d9901f181a77_SECONDO-SALDO_2026_4";
+        var k = RelTestataKey.Deserialize(id);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(k.IdEnte, Is.EqualTo("76fd95f3-c1a1-410f-95c8-a6ac00989aae"));
+            Assert.That(k.IdContratto, Is.EqualTo("97d4d355-ab9f-4a09-8fe1-d9901f181a77"));
+            Assert.That(k.TipologiaFattura, Is.EqualTo("SECONDO SALDO"), "trattino -> spazio");
+            Assert.That(k.Anno, Is.EqualTo(2026));
+            Assert.That(k.Mese, Is.EqualTo(4));
+        });
+    }
+
+    // Round-trip per le tipologie reali con spazio/punto: ToString -> Deserialize deve tornare l'originale.
+    [TestCase("PRIMO SALDO")]
+    [TestCase("SECONDO SALDO")]
+    [TestCase("VAR. SEMESTRALE")]
+    [TestCase("SEM. SOSPESI")]
+    [TestCase("ANTICIPO")]
+    public void RoundTrip_Tipologia_ConservaLoSpazio(string tipologia)
+    {
+        var originale = new RelTestataKey("ente-1", "contratto-1", tipologia, 2026, 7);
+        var ricostruita = RelTestataKey.Deserialize(originale.ToString());
+
+        Assert.That(ricostruita.TipologiaFattura, Is.EqualTo(tipologia),
+            $"Round-trip di '{tipologia}' deve conservare gli spazi (via trattino nell'id).");
+    }
+
+    [Test]
+    /// <summary>
+    /// Verifica che la deserializzazione di un id malformato con meno di cinque parti lancia un'eccezione.
+    /// </summary>
+    public void Deserialize_IdMalformato_MenoDiCinqueParti_Lancia()
+    {
+        // Un id senza tutte le parti (es. manca mese) non e' deserializzabile: la SP/query non deve
+        // ricevere valori indefiniti. Documenta il fallimento attuale (accesso a indice mancante).
+        Assert.That(() => RelTestataKey.Deserialize("ente_contratto_SECONDO-SALDO_2026"),
+            Throws.InstanceOf<IndexOutOfRangeException>());
+    }
+
+    [Test]
+    /// <summary>
+    /// Verifica che la deserializzazione di un id con anno non numerico lancia un'eccezione.
+    /// </summary>
+    public void Deserialize_AnnoNonNumerico_Lancia()
+    {
+        Assert.That(() => RelTestataKey.Deserialize("ente_contratto_SECONDO-SALDO_XXXX_4"),
+            Throws.InstanceOf<FormatException>());
+    }
+}


### PR DESCRIPTION
Introdotto SingleOrDefaultAsync<T> in DapperBase e IDatabase per gestire query che possono restituire 0 righe senza eccezione. Aggiunti test di integrazione su SingleAsync/SingleOrDefaultAsync e test unitari su RelTestataKey. Esplicitata la scelta di SingleAsync in RelTestataQueryGetByIdPersistence.